### PR TITLE
Updated the path of specollate.tar.gz in the README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The below sections explain the setup for retraining the model.
 
 ### Retrain the Model
 
-1. Download the [specollate.tar.gz](https://drive.google.com/uc?export=download&id=1iAR4a6qQQyS2pDFMRqCd7Jaofsmxwdsp) file and extract the contents using the following command:  
+1. Download the [specollate.tar.gz]([https://drive.google.com/uc?export=download&id=1iAR4a6qQQyS2pDFMRqCd7Jaofsmxwdsp](https://fiudit-my.sharepoint.com/:u:/g/personal/ppara014_fiu_edu/EbapFHQFI-5GrVwVxBDn0e8BugwpnjXQfelTakYy00mNSA?e=oZNJ7S)) file and extract the contents using the following command:  
 `tar -xzf specollate.tar.gz`  
 The extracted directory contains multiple files, including:
     - `specollate-train`: This is the executable for training SpeCollate.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The below sections explain the setup for retraining the model.
 
 ### Retrain the Model
 
-1. Download the [specollate.tar.gz](https://drive.google.com/uc?export=download&id=1iAR4a6qQQyS2pDFMRqCd7Jaofsmxwdsp](https://fiudit-my.sharepoint.com/:u:/g/personal/ppara014_fiu_edu/EbapFHQFI-5GrVwVxBDn0e8BugwpnjXQfelTakYy00mNSA?e=oZNJ7S)) file and extract the contents using the following command:  
+1. Download the [specollate.tar.gz]([https://drive.google.com/uc?export=download&id=1iAR4a6qQQyS2pDFMRqCd7Jaofsmxwdsp](https://fiudit-my.sharepoint.com/:u:/g/personal/ppara014_fiu_edu/EbapFHQFI-5GrVwVxBDn0e8BugwpnjXQfelTakYy00mNSA?e=oZNJ7S)) file and extract the contents using the following command:  
 `tar -xzf specollate.tar.gz`  
 The extracted directory contains multiple files, including:
     - `specollate-train`: This is the executable for training SpeCollate.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The below sections explain the setup for retraining the model.
 
 ### Retrain the Model
 
-1. Download the [specollate.tar.gz]([https://drive.google.com/uc?export=download&id=1iAR4a6qQQyS2pDFMRqCd7Jaofsmxwdsp](https://fiudit-my.sharepoint.com/:u:/g/personal/ppara014_fiu_edu/EbapFHQFI-5GrVwVxBDn0e8BugwpnjXQfelTakYy00mNSA?e=oZNJ7S)) file and extract the contents using the following command:  
+1. Download the [specollate.tar.gz](https://drive.google.com/uc?export=download&id=1iAR4a6qQQyS2pDFMRqCd7Jaofsmxwdsp) file and extract the contents using the following command:  
 `tar -xzf specollate.tar.gz`  
 The extracted directory contains multiple files, including:
     - `specollate-train`: This is the executable for training SpeCollate.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The below sections explain the setup for retraining the model.
 
 ### Retrain the Model
 
-1. Download the [specollate.tar.gz](https://drive.google.com/uc?export=download&id=1iAR4a6qQQyS2pDFMRqCd7Jaofsmxwdsp) file and extract the contents using the following command:  
+1. Download the [specollate.tar.gz](https://fiudit-my.sharepoint.com/:u:/g/personal/ppara014_fiu_edu/EbapFHQFI-5GrVwVxBDn0e8BugwpnjXQfelTakYy00mNSA?e=IFAylK) file and extract the contents using the following command:  
 `tar -xzf specollate.tar.gz`  
 The extracted directory contains multiple files, including:
     - `specollate-train`: This is the executable for training SpeCollate.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The below sections explain the setup for retraining the model.
 
 ### Retrain the Model
 
-1. Download the [specollate.tar.gz]([https://drive.google.com/uc?export=download&id=1iAR4a6qQQyS2pDFMRqCd7Jaofsmxwdsp](https://fiudit-my.sharepoint.com/:u:/g/personal/ppara014_fiu_edu/EbapFHQFI-5GrVwVxBDn0e8BugwpnjXQfelTakYy00mNSA?e=oZNJ7S)) file and extract the contents using the following command:  
+1. Download the [specollate.tar.gz](https://drive.google.com/uc?export=download&id=1iAR4a6qQQyS2pDFMRqCd7Jaofsmxwdsp](https://fiudit-my.sharepoint.com/:u:/g/personal/ppara014_fiu_edu/EbapFHQFI-5GrVwVxBDn0e8BugwpnjXQfelTakYy00mNSA?e=oZNJ7S)) file and extract the contents using the following command:  
 `tar -xzf specollate.tar.gz`  
 The extracted directory contains multiple files, including:
     - `specollate-train`: This is the executable for training SpeCollate.


### PR DESCRIPTION
Updated the path of specollate.tar.gz in the README.md. All files within the specollate.tar.gz archive are sourced from this "/disk/raptor-2/mtari008/specollate" location.